### PR TITLE
Error codes moved in config/errorCodes.js

### DIFF
--- a/generators/app/templates/api/responses/badRequest.js
+++ b/generators/app/templates/api/responses/badRequest.js
@@ -9,7 +9,7 @@
 module.exports = function (data, code, message, root) {
   // TODO: make transform camelCase to snake_case
   var response = _.assign({
-    code: code || 'E_BAD_REQUEST',
+    code: code || sails.config.errorCodes.badRequest,
     message: message || 'The request cannot be fulfilled due to bad syntax',
     data: data || {}
   }, root);

--- a/generators/app/templates/api/responses/created.js
+++ b/generators/app/templates/api/responses/created.js
@@ -10,7 +10,7 @@
 module.exports = function (data, code, message, root) {
   // TODO: make transform camelCase to snake_case
   var response = _.assign({
-    code: code || 'CREATED',
+    code: code || sails.config.errorCodes.created,
     message: message || 'The request has been fulfilled and resulted in a new resource being created',
     data: data || {}
   }, root);

--- a/generators/app/templates/api/responses/forbidden.js
+++ b/generators/app/templates/api/responses/forbidden.js
@@ -9,7 +9,7 @@
 module.exports = function (data, code, message, root) {
   // TODO: make transform camelCase to snake_case
   var response = _.assign({
-    code: code || 'E_FORBIDDEN',
+    code: code || sails.config.errorCodes.forbidden,
     message: message || 'User not authorized to perform the operation',
     data: data || {}
   }, root);

--- a/generators/app/templates/api/responses/notFound.js
+++ b/generators/app/templates/api/responses/notFound.js
@@ -9,7 +9,7 @@
 module.exports = function (data, code, message, root) {
   // TODO: make transform camelCase to snake_case
   var response = _.assign({
-    code: code || 'E_NOT_FOUND',
+    code: code || sails.config.errorCodes.notFound,
     message: message || 'The requested resource could not be found but may be available again in the future',
     data: data || {}
   }, root);

--- a/generators/app/templates/api/responses/ok.js
+++ b/generators/app/templates/api/responses/ok.js
@@ -10,7 +10,7 @@
 module.exports = function (data, code, message, root) {
   // TODO: make transform camelCase to snake_case
   var response = _.assign({
-    code: code || 'OK',
+    code: code || sails.config.errorCodes.ok,
     message: message || 'Operation is successfully executed',
     data: data || {}
   }, root);

--- a/generators/app/templates/api/responses/serverError.js
+++ b/generators/app/templates/api/responses/serverError.js
@@ -8,7 +8,7 @@
 module.exports = function (data, code, message, root) {
   // TODO: make transform camelCase to snake_case
   var response = _.assign({
-    code: code || 'E_INTERNAL_SERVER_ERROR',
+    code: code || sails.config.errorCodes.serverError,
     message: message || 'Something bad happened on the server',
     data: data || {}
   }, root);

--- a/generators/app/templates/api/responses/unauthorized.js
+++ b/generators/app/templates/api/responses/unauthorized.js
@@ -9,7 +9,7 @@
 module.exports = function (data, code, message, root) {
   // TODO: make transform camelCase to snake_case
   var response = _.assign({
-    code: code || 'E_UNAUTHORIZED',
+    code: code || sails.config.errorCodes.unauthorized,
     message: message || 'Missing or invalid authentication token',
     data: data || {}
   }, root);

--- a/generators/app/templates/config/errorCodes.js
+++ b/generators/app/templates/config/errorCodes.js
@@ -1,0 +1,9 @@
+module.exports.errorCodes = {
+  badRequest: 'E_BAD_REQUEST',
+  created: 'CREATED',
+  forbidden: 'E_FORBIDDEN',
+  notFound: 'E_NOT_FOUND',
+  ok: 'OK',
+  serverError: 'E_INTERNAL_SERVER_ERROR',
+  unauthorized: 'E_UNAUTHORIZED'
+};


### PR DESCRIPTION
Should fix #34 .
P.S. Also we can move the default response messages in a config file too. Something like:
```javascript
badRequest: {
  code: 'E_BAD_REQUEST',
  message: 'The request cannot be fulfilled due to bad syntax'
}
```