### PR TITLE
Default settings for Twilio in sms service config

### DIFF
--- a/src/service/templates/config/services/sms.js
+++ b/src/service/templates/config/services/sms.js
@@ -1,5 +1,10 @@
 export default {
   services: {
-    sms: {}
+    sms: {
+      provider: {
+        accountSid: '<ACCOUNT_SID>',
+        authToken: '<AUTH_TOKEN>'
+      }
+    }
   }
 }


### PR DESCRIPTION
Without such settings, SMS service looks into Environment variables for Twilio API tokens (at least on Windows) and fails if can't found them...
This makes impossible to test project right after generator create it. 
Instead generator should ask such settings (seems not done for now) or devs can just edit settings in this config file.